### PR TITLE
update pcl and fix build

### DIFF
--- a/bzl/pcl.bzl
+++ b/bzl/pcl.bzl
@@ -70,6 +70,9 @@ def _gen_pcl_config_impl(ctx):
         "${PCL_VERSION_PATCH}": ctx.attr.version_patch,
         "${PCL_DEV_VERSION}": dev_version_str,
         "${PCL_VERSION_PRETTY}": version_pretty_str,
+        "${PCL_INDEX_SIZE}": "32",
+        "${PCL_INDEX_SIGNED}": "false",
+        "${PCL_INDEX_SIGNED_STR}": "false",
         # TODO(kgreenek): Will this ever need to be different here?
         "${VTK_RENDERING_BACKEND_OPENGL_VERSION}": "1",
     }
@@ -91,6 +94,8 @@ def _gen_pcl_config_impl(ctx):
             ("HAVE_ENSENSO 1", False),
             ("HAVE_DAVIDSDK 1", False),
             ("HAVE_PNG", True),
+            ("HAVE_QVTK 1", False),
+            ("HAVE_FZAPI 1", False),
         ),
     )
 

--- a/bzl/repositories.bzl
+++ b/bzl/repositories.bzl
@@ -71,10 +71,10 @@ def pcl_repositories():
     maybe(
         http_archive,
         name = "pcl",
+	sha256 = "b52e1424686843c94c5771795a79d7a33296708ce23173a3f32769c30ee3a993",
         build_file = "@rules_pcl//third_party:pcl.BUILD",
-        sha256 = "85fd437a1b326de57d85d9862a1ca3e833301f8d78a1cafdbe48113ffd9f9168",
-        strip_prefix = "pcl-1d3622c1e624994bc013e3e66bc5d98fbb807a89",
-        urls = ["https://github.com/PointCloudLibrary/pcl/archive/1d3622c1e624994bc013e3e66bc5d98fbb807a89.tar.gz"],
+        strip_prefix = "pcl-pcl-1.10.0",
+        urls = ["https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.10.0.zip"],
     )
 
     maybe(


### PR DESCRIPTION
The current configuration cannot build the ICP functionality of PCL. This PR updates PCL and fixes the Cmake config to be able to have the ICP feature