### PR TITLE
Upgrade pcl to 1.14.1

### DIFF
--- a/bzl/pcl.bzl
+++ b/bzl/pcl.bzl
@@ -96,6 +96,8 @@ def _gen_pcl_config_impl(ctx):
             ("HAVE_PNG", True),
             ("HAVE_QVTK 1", False),
             ("HAVE_FZAPI 1", False),
+            ("HAVE_ZLIB", True),
+            ("PCL_PREFER_BOOST_FILESYSTEM", False),
         ),
     )
 

--- a/bzl/repositories.bzl
+++ b/bzl/repositories.bzl
@@ -75,10 +75,10 @@ def pcl_repositories():
     maybe(
         http_archive,
         name = "pcl",
-        sha256 = "8ab98a9db371d822de0859084a375a74bdc7f31c96d674147710cf4101b79621",
+        sha256 = "5dc5e09509644f703de9a3fb76d99ab2cc67ef53eaf5637db2c6c8b933b28af6",
         build_file = "@rules_pcl//third_party:pcl.BUILD",
-        strip_prefix = "pcl-pcl-1.13.1",
-        urls = ["https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.13.1.tar.gz"],
+        strip_prefix = "pcl-pcl-1.14.1",
+        urls = ["https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.14.1.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
PCL 1.14.1 has been released, which fix many bugs: https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md

So upgrade the pcl version in rules_pcl